### PR TITLE
Use FPC environment variable in build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ end;
 
 ## Build & Run Tests
 
+Before running the scripts below make sure the FreePascal compiler is installed.
+If it is not available in your `PATH`, set the `FPC` environment variable to the
+full path of the `fpc` executable.
+
 ### Windows
 
 Run the batch script:
@@ -72,7 +76,7 @@ You will see FPCUnit test output with full results in XML and console form.
 
 ## Requirements
 
-* FreePascal 3.0+
+* FreePascal 3.0+ (ensure `fpc` is accessible or set the `FPC` environment variable)
 * Optional: [Lazarus IDE](https://www.lazarus-ide.org/) for integration in GUI-based tools
 
 ---

--- a/build_tests.bat
+++ b/build_tests.bat
@@ -2,9 +2,19 @@
 echo Building tests for fpidn and fppunycode...
 echo.
 
+REM Determine FreePascal compiler
+if "%FPC%"=="" (
+    for /f "delims=" %%i in ('where fpc 2^>nul') do set "FPC=%%i"
+)
+if "%FPC%"=="" (
+    echo ERROR: FreePascal compiler (fpc) not found. Please install FPC and set the FPC environment variable.
+    pause
+    exit /b 1
+)
+
 REM Compile console test application
 echo Compiling the console test application...
-C:\lazarus-4.0\fpc\bin\x86_64-win64\fpc.exe ^
+%FPC% ^
   -Mobjfpc -Scghi -O1 -g -gl -l -vewnhibq ^
   -Fu. -Fu..\ -FUlib\ ^
   tests\testconsole.lpr

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -3,9 +3,16 @@
 echo "Building tests for fpidn and fppunycode..."
 echo
 
+# Determine FreePascal compiler
+FPC_CMD="${FPC:-$(command -v fpc)}"
+if [ -z "$FPC_CMD" ] || [ ! -x "$FPC_CMD" ]; then
+  echo "ERROR: FreePascal compiler (fpc) not found. Install FPC and set the FPC environment variable if needed."
+  exit 1
+fi
+
 # Compile the console test application
 echo "Compiling the console test application..."
-fpc -Mobjfpc -Scghi -O1 -g -gl -l -vewnhibq \
+"$FPC_CMD" -Mobjfpc -Scghi -O1 -g -gl -l -vewnhibq \
   -Fu. -Fu.. -FUlib/ \
   tests/testconsole.lpr
 


### PR DESCRIPTION
## Summary
- make build scripts rely on `FPC` env var or `which fpc`
- detect missing compiler and exit with an error
- document the need for FPC and environment variable in README

## Testing
- `./build_tests.sh` *(fails: FreePascal compiler not found)*

------
https://chatgpt.com/codex/tasks/task_e_684554285ee48328b0a6830d18cdae92