### PR TITLE
Add Pascal benchmarks for fppunycode and fpidn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,7 @@ lib/
 *.app/
 
 # temporary hide
-benchmarks/
+# Ignore generated benchmark binaries and results
+benchmarks/benchconsole
+benchmarks/benchconsole.exe
+benchmarks/results.csv

--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ You will see FPCUnit test output with full results in XML and console form.
 
 ---
 
+## Build & Run Benchmarks
+
+The repository also includes simple performance benchmarks for `fppunycode` and `fpidn`.
+They output results to the console and save them to `benchmarks/results.csv`.
+
+### Windows
+
+Run the batch script:
+
+```cmd
+build_benchmarks.bat
+```
+
+### Linux/macOS
+
+Run the shell script:
+
+```bash
+./build_benchmarks.sh
+```
+
+---
+
 ## Requirements
 
 * FreePascal 3.0+ (ensure `fpc` is accessible or set the `FPC` environment variable)

--- a/benchmarks/benchconsole.lpi
+++ b/benchmarks/benchconsole.lpi
@@ -58,13 +58,14 @@
             <Filename Value="benchconsole"/>
           </Target>
           <SearchPaths>
+            <IncludeFiles Value="$(ProjOutDir)"/>
             <OtherUnitFiles Value=".."/>
             <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <CodeGeneration>
             <SmartLinkUnit Value="True"/>
             <Optimizations>
-              <OptimizationLevel Value="3"/>
+              <OptimizationLevel Value="4"/>
             </Optimizations>
           </CodeGeneration>
           <Linking>

--- a/benchmarks/benchconsole.lpi
+++ b/benchmarks/benchconsole.lpi
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="benchconsole"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+      <Item Name="Debug">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="benchconsole"/>
+          </Target>
+          <SearchPaths>
+            <OtherUnitFiles Value=".."/>
+            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <Parsing>
+            <SyntaxOptions>
+              <IncludeAssertionCode Value="True"/>
+            </SyntaxOptions>
+          </Parsing>
+          <CodeGeneration>
+            <Checks>
+              <IOChecks Value="True"/>
+              <RangeChecks Value="True"/>
+              <OverflowChecks Value="True"/>
+              <StackChecks Value="True"/>
+            </Checks>
+            <VerifyObjMethodCallValidity Value="True"/>
+          </CodeGeneration>
+          <Linking>
+            <Debugging>
+              <DebugInfoType Value="dsDwarf3"/>
+              <UseHeaptrc Value="True"/>
+              <TrashVariables Value="True"/>
+            </Debugging>
+          </Linking>
+        </CompilerOptions>
+      </Item>
+      <Item Name="Release">
+        <CompilerOptions>
+          <Version Value="11"/>
+          <PathDelim Value="\"/>
+          <Target>
+            <Filename Value="benchconsole"/>
+          </Target>
+          <SearchPaths>
+            <OtherUnitFiles Value=".."/>
+            <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+          </SearchPaths>
+          <CodeGeneration>
+            <SmartLinkUnit Value="True"/>
+            <Optimizations>
+              <OptimizationLevel Value="3"/>
+            </Optimizations>
+          </CodeGeneration>
+          <Linking>
+            <Debugging>
+              <GenerateDebugInfo Value="False"/>
+              <RunWithoutDebug Value="True"/>
+              <StripSymbols Value="True"/>
+            </Debugging>
+            <LinkSmart Value="True"/>
+          </Linking>
+        </CompilerOptions>
+      </Item>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <Units>
+      <Unit>
+        <Filename Value="benchconsole.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+      <Unit>
+        <Filename Value="..\fppunycode.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value="benchconsole"/>
+    </Target>
+    <SearchPaths>
+      <OtherUnitFiles Value=".."/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <Linking>
+      <Debugging>
+        <DebugInfoType Value="dsDwarf3"/>
+      </Debugging>
+    </Linking>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions>
+      <Item>
+        <Name Value="EAbort"/>
+      </Item>
+      <Item>
+        <Name Value="ECodetoolError"/>
+      </Item>
+      <Item>
+        <Name Value="EFOpenError"/>
+      </Item>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/benchmarks/benchconsole.lpr
+++ b/benchmarks/benchconsole.lpr
@@ -1,0 +1,86 @@
+program benchconsole;
+
+{$mode objfpc}{$H+}
+
+uses
+  SysUtils, fppunycode, fpidn;
+
+type
+  TBenchmark = record
+    Name: string;
+    Iterations: Integer;
+    DurationMs: QWord;
+    OpsPerSec: Double;
+  end;
+
+  TConvFunc = function(const S: string): string;
+
+procedure RunBench(const Name, Input: string; Func: TConvFunc; Iterations: Integer; out Res: TBenchmark);
+var
+  i: Integer;
+  StartT, EndT: QWord;
+  Last, Expected: string;
+begin
+  Expected := Func(Input);
+  StartT := GetTickCount64;
+  for i := 1 to Iterations do
+    Last := Func(Input);
+  EndT := GetTickCount64;
+  if Last <> Expected then
+    raise Exception.CreateFmt('%s failed: expected %s got %s', [Name, Expected, Last]);
+  Res.Name := Name;
+  Res.Iterations := Iterations;
+  Res.DurationMs := EndT - StartT;
+  if Res.DurationMs > 0 then
+    Res.OpsPerSec := (Iterations * 1000.0) / Res.DurationMs
+  else
+    Res.OpsPerSec := Iterations;
+end;
+
+procedure SaveCSV(const FileName: string; const Results: array of TBenchmark);
+var
+  F: TextFile;
+  i: Integer;
+begin
+  AssignFile(F, FileName);
+  Rewrite(F);
+  WriteLn(F, 'Name,Iterations,DurationMs,OpsPerSec');
+  for i := 0 to High(Results) do
+    WriteLn(F, Format('"%s",%d,%d,%.2f',
+      [Results[i].Name, Results[i].Iterations, Results[i].DurationMs, Results[i].OpsPerSec]));
+  CloseFile(F);
+end;
+
+procedure PrintResults(const Results: array of TBenchmark);
+var
+  i: Integer;
+begin
+  Writeln('Benchmark results:');
+  Writeln(Format('%-30s %10s %12s %12s', ['Name','Iterations','Duration','Ops/s']));
+  for i := 0 to High(Results) do
+    Writeln(Format('%-30s %10d %12d %12.2f',
+      [Results[i].Name, Results[i].Iterations, Results[i].DurationMs, Results[i].OpsPerSec]));
+end;
+
+const
+  ITERATIONS = 10000;
+
+var
+  Results: array of TBenchmark;
+  LongStr, LongPuny: string;
+begin
+  LongStr := StringOfChar('т', 1000);
+  LongPuny := UTF8ToPunycode(LongStr);
+
+  SetLength(Results, 6);
+
+  RunBench('UTF8ToPunycode short', 'тест', @UTF8ToPunycode, ITERATIONS, Results[0]);
+  RunBench('PunycodeToUTF8 short', 'e1aybc', @PunycodeToUTF8, ITERATIONS, Results[1]);
+  RunBench('UTF8ToPunycode long', LongStr, @UTF8ToPunycode, ITERATIONS, Results[2]);
+  RunBench('PunycodeToUTF8 long', LongPuny, @PunycodeToUTF8, ITERATIONS, Results[3]);
+  RunBench('UnicodeToIDN', 'пример.рф', @UnicodeToIDN, ITERATIONS, Results[4]);
+  RunBench('IDNToUnicode', 'xn--e1afmkfd.xn--p1ai', @IDNToUnicode, ITERATIONS, Results[5]);
+
+  PrintResults(Results);
+  SaveCSV('benchmarks/results.csv', Results);
+end.

--- a/benchmarks/benchconsole.lpr
+++ b/benchmarks/benchconsole.lpr
@@ -3,7 +3,8 @@ program benchconsole;
 {$mode objfpc}{$H+}
 
 uses
-  SysUtils, fppunycode, fpidn;
+  SysUtils, fppunycode, fpidn
+  ;
 
 type
   TBenchmark = record
@@ -21,6 +22,7 @@ var
   StartT, EndT: QWord;
   Last, Expected: string;
 begin
+  Last:=EmptyStr;
   Expected := Func(Input);
   StartT := GetTickCount64;
   for i := 1 to Iterations do
@@ -68,10 +70,14 @@ const
 var
   Results: array of TBenchmark;
   LongStr, LongPuny: string;
+  i: Integer;
 begin
-  LongStr := DupeString('т', 1000);
+  LongStr:=EmptyStr;
+  for i := 1 to 10000 do
+    LongStr+='т';
   LongPuny := UTF8ToPunycode(LongStr);
 
+  Initialize(Results);
   SetLength(Results, 6);
 
   RunBench('UTF8ToPunycode short', 'тест', @UTF8ToPunycode, ITERATIONS, Results[0]);
@@ -82,5 +88,5 @@ begin
   RunBench('IDNToUnicode', 'xn--e1afmkfd.xn--p1ai', @IDNToUnicode, ITERATIONS, Results[5]);
 
   PrintResults(Results);
-  SaveCSV('benchmarks/results.csv', Results);
+  SaveCSV('results.csv', Results);
 end.

--- a/benchmarks/benchconsole.lpr
+++ b/benchmarks/benchconsole.lpr
@@ -48,7 +48,7 @@ begin
   Rewrite(F);
   WriteLn(F, 'Name,Iterations,DurationMs,OpsPerSec');
   for i := 0 to High(Results) do
-    WriteLn(F, Format('"%s",%d,%d,%.2f',
+    WriteLn(F, Format('"%s";%d;%d;%.2f',
       [Results[i].Name, Results[i].Iterations, Results[i].DurationMs, Results[i].OpsPerSec]));
   CloseFile(F);
 end;
@@ -73,7 +73,7 @@ var
   i: Integer;
 begin
   LongStr:=EmptyStr;
-  for i := 1 to 10000 do
+  for i := 1 to 1000 do
     LongStr+='т';
   LongPuny := UTF8ToPunycode(LongStr);
 

--- a/benchmarks/benchconsole.lpr
+++ b/benchmarks/benchconsole.lpr
@@ -65,7 +65,7 @@ begin
 end;
 
 const
-  ITERATIONS = 10000;
+  ITERATIONS = 100000;
 
 var
   Results: array of TBenchmark;

--- a/benchmarks/benchconsole.lpr
+++ b/benchmarks/benchconsole.lpr
@@ -69,7 +69,7 @@ var
   Results: array of TBenchmark;
   LongStr, LongPuny: string;
 begin
-  LongStr := StringOfChar('т', 1000);
+  LongStr := DupeString('т', 1000);
   LongPuny := UTF8ToPunycode(LongStr);
 
   SetLength(Results, 6);

--- a/build_benchmarks.bat
+++ b/build_benchmarks.bat
@@ -1,0 +1,30 @@
+@echo off
+
+echo Building benchmarks...
+
+if "%FPC%"=="" (
+    for /f "delims=" %%i in ('where fpc 2^>nul') do set "FPC=%%i"
+)
+if "%FPC%"=="" (
+    echo ERROR: FreePascal compiler (fpc) not found. Please install FPC and set the FPC environment variable.
+    pause
+    exit /b 1
+)
+
+%FPC% ^
+  -Mobjfpc -Scghi -O1 -g -gl -l -vewnhibq ^
+  -Fu. -FUlib\ ^
+  benchmarks\benchconsole.lpr
+
+if %ERRORLEVEL% NEQ 0 (
+    echo ERROR: Failed to compile benchmarks
+    pause
+    exit /b 1
+)
+
+echo Running benchmarks...
+benchmarks\benchconsole.exe
+
+echo.
+echo Benchmarks completed.
+pause

--- a/build_benchmarks.sh
+++ b/build_benchmarks.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Building benchmarks..."
+
+FPC_CMD="${FPC:-$(command -v fpc)}"
+if [ -z "$FPC_CMD" ] || [ ! -x "$FPC_CMD" ]; then
+  echo "ERROR: FreePascal compiler (fpc) not found. Install FPC and set the FPC environment variable if needed."
+  exit 1
+fi
+
+"$FPC_CMD" -Mobjfpc -Scghi -O1 -g -gl -l -vewnhibq \
+  -Fu. -FUlib/ \
+  benchmarks/benchconsole.lpr
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to compile benchmarks"
+  exit 1
+fi
+
+echo "Running benchmarks..."
+./benchmarks/benchconsole
+
+echo
+echo "Benchmarks completed."


### PR DESCRIPTION
## Summary
- add `benchconsole` program that benchmarks encoding/decoding
- provide scripts to build and run benchmarks on Linux and Windows
- update README with instructions
- clean `.gitignore` and ignore benchmark artifacts
